### PR TITLE
Feat/auth 카카오 소셜 로그인 방식 개선

### DIFF
--- a/core-auth/src/main/java/com/onetuks/coreauth/config/AuthPermittedEndpoint.java
+++ b/core-auth/src/main/java/com/onetuks/coreauth/config/AuthPermittedEndpoint.java
@@ -6,6 +6,15 @@ public class AuthPermittedEndpoint {
 
   protected static final String[] ENDPOINTS =
       new String[] {
-        "/", "/auth/kakao", "/auth/google", "/auth/naver", "/error", "/docs/**", "/actuator/**"
+        "/",
+        "/auth/kakao",
+        "/auth/google",
+        "/auth/naver",
+        "/auth/postman/kakao",
+        "/auth/postman/google",
+        "/auth/postman/naver",
+        "/error",
+        "/docs/**",
+        "/actuator/**"
       };
 }

--- a/core-auth/src/main/java/com/onetuks/coreauth/config/CorsConfig.java
+++ b/core-auth/src/main/java/com/onetuks/coreauth/config/CorsConfig.java
@@ -10,7 +10,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 public class CorsConfig {
 
-  private static final List<String> ALLOWED_ORIGINS = List.of("http://localhost:3000", "*");
+  private static final List<String> ALLOWED_ORIGINS = List.of("http://localhost:8000", "*");
 
   private static final List<String> ALLOWED_METHODS =
       List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS");

--- a/core-auth/src/main/java/com/onetuks/coreauth/config/KakaoClientConfig.java
+++ b/core-auth/src/main/java/com/onetuks/coreauth/config/KakaoClientConfig.java
@@ -1,10 +1,12 @@
 package com.onetuks.coreauth.config;
 
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 
+@Getter
 @Configuration
 public class KakaoClientConfig {
 
@@ -19,7 +21,7 @@ public class KakaoClientConfig {
         .clientId(clientId)
         .clientSecret(clientSecret)
         .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-        .redirectUri("http://localhost:8080/login/oauth2/code/kakao")
+        .redirectUri("http://localhost:8000/login/oauth2/callback")
         .authorizationUri("https://kauth.kakao.com/oauth/authorize")
         .tokenUri("https://kauth.kakao.com/oauth/token")
         .userInfoUri("https://kapi.kakao.com/v2/user/me")

--- a/core-auth/src/main/java/com/onetuks/coreauth/controller/AuthRestController.java
+++ b/core-auth/src/main/java/com/onetuks/coreauth/controller/AuthRestController.java
@@ -49,26 +49,34 @@ public class AuthRestController {
     this.memberService = memberService;
   }
 
+  @PostMapping(path = "/postman/kakao")
+  public ResponseEntity<LoginResponse> kakaoLoginWithAuthToken(HttpServletRequest request) {
+    LoginResult loginResult =
+        oAuth2ClientService.loginWithAuthToken(KAKAO, request.getHeader(HEADER_AUTHORIZATION));
+
+    return ResponseEntity.status(HttpStatus.OK).body(LoginResponse.from(loginResult));
+  }
+
   @PostMapping(path = "/kakao")
-  public ResponseEntity<LoginResponse> kakaoLogin(HttpServletRequest request) {
+  public ResponseEntity<LoginResponse> kakaoLoginWithAuthCode(HttpServletRequest request) {
     LoginResult loginResult =
-        oAuth2ClientService.login(KAKAO, request.getHeader(HEADER_AUTHORIZATION));
+        oAuth2ClientService.loginWithAuthCode(KAKAO, request.getHeader(HEADER_AUTHORIZATION));
 
     return ResponseEntity.status(HttpStatus.OK).body(LoginResponse.from(loginResult));
   }
 
-  @PostMapping(path = "/google")
-  public ResponseEntity<LoginResponse> googleLogin(HttpServletRequest request) {
+  @PostMapping(path = "/postman/google")
+  public ResponseEntity<LoginResponse> googleLoginWithAuthToken(HttpServletRequest request) {
     LoginResult loginResult =
-        oAuth2ClientService.login(GOOGLE, request.getHeader(HEADER_AUTHORIZATION));
+        oAuth2ClientService.loginWithAuthToken(GOOGLE, request.getHeader(HEADER_AUTHORIZATION));
 
     return ResponseEntity.status(HttpStatus.OK).body(LoginResponse.from(loginResult));
   }
 
-  @PostMapping(path = "/naver")
-  public ResponseEntity<LoginResponse> naverLogin(HttpServletRequest request) {
+  @PostMapping(path = "/postman/naver")
+  public ResponseEntity<LoginResponse> naverLoginWithAuthToken(HttpServletRequest request) {
     LoginResult loginResult =
-        oAuth2ClientService.login(NAVER, request.getHeader(HEADER_AUTHORIZATION));
+        oAuth2ClientService.loginWithAuthToken(NAVER, request.getHeader(HEADER_AUTHORIZATION));
 
     return ResponseEntity.status(HttpStatus.OK).body(LoginResponse.from(loginResult));
   }

--- a/core-auth/src/main/java/com/onetuks/coreauth/oauth/dto/KakaoAuthToken.java
+++ b/core-auth/src/main/java/com/onetuks/coreauth/oauth/dto/KakaoAuthToken.java
@@ -1,0 +1,10 @@
+package com.onetuks.coreauth.oauth.dto;
+
+public record KakaoAuthToken(
+    String token_type,
+    String access_token,
+    String id_token,
+    int expires_in,
+    String refresh_token,
+    int refresh_token_expires_in,
+    String scope) {}

--- a/core-auth/src/main/java/com/onetuks/coreauth/oauth/strategy/ClientProviderStrategy.java
+++ b/core-auth/src/main/java/com/onetuks/coreauth/oauth/strategy/ClientProviderStrategy.java
@@ -1,8 +1,11 @@
 package com.onetuks.coreauth.oauth.strategy;
 
+import com.onetuks.coreauth.oauth.dto.KakaoAuthToken;
 import com.onetuks.coredomain.member.model.vo.AuthInfo;
 
 public interface ClientProviderStrategy {
 
-  AuthInfo getAuthInfo(String accessToken);
+  AuthInfo getAuthInfo(String authToken);
+
+  KakaoAuthToken getOAuth2Token(String authCode);
 }

--- a/core-auth/src/main/java/com/onetuks/coreauth/oauth/strategy/GoogleClientProviderStrategy.java
+++ b/core-auth/src/main/java/com/onetuks/coreauth/oauth/strategy/GoogleClientProviderStrategy.java
@@ -2,6 +2,7 @@ package com.onetuks.coreauth.oauth.strategy;
 
 import com.onetuks.coreauth.exception.TokenValidFailedException;
 import com.onetuks.coreauth.oauth.dto.GoogleUser;
+import com.onetuks.coreauth.oauth.dto.KakaoAuthToken;
 import com.onetuks.coredomain.member.model.vo.AuthInfo;
 import com.onetuks.coreobj.enums.member.ClientProvider;
 import com.onetuks.coreobj.enums.member.RoleType;
@@ -26,12 +27,12 @@ public class GoogleClientProviderStrategy implements ClientProviderStrategy {
   }
 
   @Override
-  public AuthInfo getAuthInfo(String accessToken) {
+  public AuthInfo getAuthInfo(String authToken) {
     GoogleUser googleUser =
         webClient
             .get()
             .uri("https://www.googleapis.com/oauth2/v3/userinfo")
-            .headers(httpHeaders -> httpHeaders.set("Authorization", accessToken))
+            .headers(httpHeaders -> httpHeaders.set("Authorization", authToken))
             .retrieve()
             .onStatus(
                 HttpStatusCode::is4xxClientError,
@@ -52,5 +53,10 @@ public class GoogleClientProviderStrategy implements ClientProviderStrategy {
         .clientProvider(ClientProvider.GOOGLE)
         .roles(List.of(RoleType.USER))
         .build();
+  }
+
+  @Override
+  public KakaoAuthToken getOAuth2Token(String authCode) {
+    return null;
   }
 }

--- a/core-auth/src/main/java/com/onetuks/coreauth/oauth/strategy/KakaoClientProviderStrategy.java
+++ b/core-auth/src/main/java/com/onetuks/coreauth/oauth/strategy/KakaoClientProviderStrategy.java
@@ -1,6 +1,8 @@
 package com.onetuks.coreauth.oauth.strategy;
 
+import com.onetuks.coreauth.config.KakaoClientConfig;
 import com.onetuks.coreauth.exception.TokenValidFailedException;
+import com.onetuks.coreauth.oauth.dto.KakaoAuthToken;
 import com.onetuks.coreauth.oauth.dto.KakaoUser;
 import com.onetuks.coredomain.member.model.vo.AuthInfo;
 import com.onetuks.coreobj.enums.member.ClientProvider;
@@ -12,6 +14,9 @@ import java.util.Objects;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -20,18 +25,25 @@ import reactor.core.publisher.Mono;
 public class KakaoClientProviderStrategy implements ClientProviderStrategy {
 
   private final WebClient webClient;
+  private final KakaoClientConfig kakaoClientConfig;
 
-  public KakaoClientProviderStrategy(WebClient webClient) {
+  public KakaoClientProviderStrategy(WebClient webClient, KakaoClientConfig kakaoClientConfig) {
     this.webClient = webClient;
+    this.kakaoClientConfig = kakaoClientConfig;
   }
 
   @Override
-  public AuthInfo getAuthInfo(String accessToken) {
+  public AuthInfo getAuthInfo(String authToken) {
     KakaoUser kakaoUser =
         webClient
             .get()
-            .uri("https://kapi.kakao.com/v2/user/me")
-            .headers(httpHeaders -> httpHeaders.set("Authorization", accessToken))
+            .uri(
+                kakaoClientConfig
+                    .kakaoClientRegistration()
+                    .getProviderDetails()
+                    .getUserInfoEndpoint()
+                    .getUri())
+            .headers(httpHeaders -> httpHeaders.set("Authorization", authToken))
             .retrieve()
             .onStatus(
                 HttpStatusCode::is4xxClientError,
@@ -52,5 +64,37 @@ public class KakaoClientProviderStrategy implements ClientProviderStrategy {
         .clientProvider(ClientProvider.KAKAO)
         .roles(List.of(RoleType.USER))
         .build();
+  }
+
+  @Override
+  public KakaoAuthToken getOAuth2Token(String authCode) {
+    return webClient
+        .post()
+        .uri(kakaoClientConfig.kakaoClientRegistration().getProviderDetails().getTokenUri())
+        .headers(
+            httpHeaders ->
+                httpHeaders.set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8"))
+        .body(BodyInserters.fromFormData(buildFormData(authCode)))
+        .retrieve()
+        .onStatus(
+            HttpStatusCode::is4xxClientError,
+            clientResponse ->
+                Mono.error(new TokenValidFailedException(ErrorCode.UNAUTHORIZED_TOKEN)))
+        .onStatus(
+            HttpStatusCode::is5xxServerError,
+            clientResponse ->
+                Mono.error(new TokenValidFailedException(ErrorCode.OAUTH_CLIENT_SERVER_ERROR)))
+        .bodyToMono(KakaoAuthToken.class)
+        .block();
+  }
+
+  private MultiValueMap<String, String> buildFormData(String authToken) {
+    MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+    formData.add("grant_type", "authorization_code");
+    formData.add("client_id", kakaoClientConfig.getClientId());
+    formData.add("client_secret", kakaoClientConfig.getClientSecret());
+    formData.add("redirect_uri", kakaoClientConfig.kakaoClientRegistration().getRedirectUri());
+    formData.add("code", authToken);
+    return formData;
   }
 }

--- a/core-auth/src/main/java/com/onetuks/coreauth/oauth/strategy/NaverClientProviderStrategy.java
+++ b/core-auth/src/main/java/com/onetuks/coreauth/oauth/strategy/NaverClientProviderStrategy.java
@@ -1,6 +1,7 @@
 package com.onetuks.coreauth.oauth.strategy;
 
 import com.onetuks.coreauth.exception.TokenValidFailedException;
+import com.onetuks.coreauth.oauth.dto.KakaoAuthToken;
 import com.onetuks.coreauth.oauth.dto.NaverUser;
 import com.onetuks.coredomain.member.model.vo.AuthInfo;
 import com.onetuks.coreobj.enums.member.ClientProvider;
@@ -26,12 +27,12 @@ public class NaverClientProviderStrategy implements ClientProviderStrategy {
   }
 
   @Override
-  public AuthInfo getAuthInfo(String accessToken) {
+  public AuthInfo getAuthInfo(String authToken) {
     NaverUser naverUser =
         webClient
             .get()
             .uri("https://openapi.naver.com/v1/nid/me")
-            .headers(httpHeaders -> httpHeaders.set("Authorization", accessToken))
+            .headers(httpHeaders -> httpHeaders.set("Authorization", authToken))
             .retrieve()
             .onStatus(
                 HttpStatusCode::is4xxClientError,
@@ -53,5 +54,10 @@ public class NaverClientProviderStrategy implements ClientProviderStrategy {
         .clientProvider(ClientProvider.NAVER)
         .roles(List.of(RoleType.USER))
         .build();
+  }
+
+  @Override
+  public KakaoAuthToken getOAuth2Token(String authCode) {
+    return null;
   }
 }

--- a/core-auth/src/test/java/com/onetuks/coreauth/service/OAuth2ClientServiceTest.java
+++ b/core-auth/src/test/java/com/onetuks/coreauth/service/OAuth2ClientServiceTest.java
@@ -28,7 +28,7 @@ class OAuth2ClientServiceTest extends CoreAuthIntegrationTest {
 
   @Test
   @DisplayName("구글 소셜 로그인 클라이언트를 활용해 로그인한다.")
-  void login_GoogleClient_Test() {
+  void login_WithAuthToken_GoogleClient_Test() {
     // Given
     ClientProvider clientProvider = ClientProvider.GOOGLE;
     AuthInfo authInfo =
@@ -46,7 +46,8 @@ class OAuth2ClientServiceTest extends CoreAuthIntegrationTest {
     given(memberService.createMemberIfNotExists(authInfo)).willReturn(memberAuthResult);
 
     // When
-    LoginResult result = oAuth2ClientService.login(clientProvider, "googleAccessToken");
+    LoginResult result =
+        oAuth2ClientService.loginWithAuthToken(clientProvider, "googleAccessToken");
 
     // Then
     assertAll(

--- a/core-web/src/main/java/com/onetuks/coreweb/config/URIBuilder.java
+++ b/core-web/src/main/java/com/onetuks/coreweb/config/URIBuilder.java
@@ -1,4 +1,4 @@
-package com.onetuks.scmdomain.verification.webclient;
+package com.onetuks.coreweb.config;
 
 import java.net.URI;
 import org.springframework.stereotype.Component;
@@ -13,5 +13,12 @@ public class URIBuilder {
     factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
 
     return factory.uriString(baseUri).queryParams(params).build();
+  }
+
+  public URI buildUri(String uri) {
+    DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory();
+    factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+
+    return factory.uriString(uri).build();
   }
 }

--- a/domain/scm-domain/src/main/java/com/onetuks/scmdomain/verification/webclient/BusinessNumberWebClient.java
+++ b/domain/scm-domain/src/main/java/com/onetuks/scmdomain/verification/webclient/BusinessNumberWebClient.java
@@ -1,6 +1,7 @@
 package com.onetuks.scmdomain.verification.webclient;
 
 import com.onetuks.coreobj.error.ErrorCode;
+import com.onetuks.coreweb.config.URIBuilder;
 import com.onetuks.coreweb.config.WebClientConfig;
 import com.onetuks.scmdomain.verification.webclient.dto.request.BusinessNumberRequest;
 import com.onetuks.scmdomain.verification.webclient.dto.response.BusinessNumberResponse;

--- a/domain/scm-domain/src/main/java/com/onetuks/scmdomain/verification/webclient/IsbnWebClient.java
+++ b/domain/scm-domain/src/main/java/com/onetuks/scmdomain/verification/webclient/IsbnWebClient.java
@@ -1,6 +1,7 @@
 package com.onetuks.scmdomain.verification.webclient;
 
 import com.onetuks.coreobj.error.ErrorCode;
+import com.onetuks.coreweb.config.URIBuilder;
 import com.onetuks.coreweb.config.WebClientConfig;
 import com.onetuks.scmdomain.verification.webclient.dto.result.RegistrationIsbnResult;
 import org.springframework.beans.factory.annotation.Value;

--- a/domain/scm-domain/src/main/java/com/onetuks/scmdomain/verification/webclient/MailOrderSalesWebClient.java
+++ b/domain/scm-domain/src/main/java/com/onetuks/scmdomain/verification/webclient/MailOrderSalesWebClient.java
@@ -1,6 +1,7 @@
 package com.onetuks.scmdomain.verification.webclient;
 
 import com.onetuks.coreobj.error.ErrorCode;
+import com.onetuks.coreweb.config.URIBuilder;
 import com.onetuks.coreweb.config.WebClientConfig;
 import com.onetuks.scmdomain.verification.webclient.dto.response.MailOrderSalesResponse;
 import org.springframework.beans.factory.annotation.Value;

--- a/storage/db-storage/src/main/java/com/onetuks/dbstorage/member/converter/MemberConverter.java
+++ b/storage/db-storage/src/main/java/com/onetuks/dbstorage/member/converter/MemberConverter.java
@@ -18,11 +18,11 @@ public class MemberConverter {
         member.authInfo().socialId(),
         member.authInfo().clientProvider(),
         member.authInfo().roles(),
-        member.nickname().nicknameValue(),
+        member.nickname() == null ? null : member.nickname().nicknameValue(),
         member.profileImgFilePath().getUri(),
         member.isAlarmPermitted(),
-        member.defaultAddressInfo().address(),
-        member.defaultAddressInfo().addressDetail());
+        member.defaultAddressInfo() == null ? null : member.defaultAddressInfo().address(),
+        member.defaultAddressInfo() == null ? null : member.defaultAddressInfo().addressDetail());
   }
 
   public Member toDomain(MemberEntity memberEntity) {


### PR DESCRIPTION
# 작업내용
- 기존: OAuth2 토큰으로 인증하던 방식
- 변경: OAuth2 코드로 인증하는 방식
# 이유
- 클라이언트에서 OAuth2 로그인 시 Cors 에러
- 서버에서 소셜 로그인 로직의 대부분을 담당하는 것이 좋겠다는 판단.